### PR TITLE
[TKISS-225] Raise error if cannot destroy by destroy!

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,7 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 155
+  Max: 160
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -85,6 +85,14 @@ class ParanoidTest < ParanoidBaseTest
     assert_not_nil pt.paranoid_value
   end
 
+  def test_halted_destroy
+    pt = ParanoidTime.create!(name: "john", destroyable: false)
+
+    assert_raises ActiveRecord::RecordNotDestroyed do
+      pt.destroy!
+    end
+  end
+
   def test_non_persisted_destroy_fully!
     pt = ParanoidTime.new
     assert_nil pt.paranoid_value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -265,6 +265,18 @@ class ParanoidTime < ActiveRecord::Base
   has_one :has_one_not_paranoid, dependent: :destroy
 
   belongs_to :not_paranoid, dependent: :destroy
+
+  attr_accessor :destroyable
+
+  before_destroy :ensure_destroyable
+
+  protected
+
+  def ensure_destroyable
+    return if destroyable.nil?
+
+    throw(:abort) unless destroyable
+  end
 end
 
 class ParanoidBoolean < ActiveRecord::Base


### PR DESCRIPTION
This PR is to tackle the issue mentioned in https://github.com/ActsAsParanoid/acts_as_paranoid/issues/221

According to https://apidock.com/rails/ActiveRecord/Persistence/destroy%21, the `destroy!` should raise an error `ActiveRecord::RecordNotDestroyed` if the `abort` signal is thrown